### PR TITLE
fix: allow short press action when long press id is 0

### DIFF
--- a/streamdeck-vjoy-w4rl0ck/Actions/ToggleButtonAction.cs
+++ b/streamdeck-vjoy-w4rl0ck/Actions/ToggleButtonAction.cs
@@ -59,8 +59,12 @@ public class ToggleButtonAction : KeypadBase
 
     public override void KeyReleased(KeyPayload payload)
     {
-        if (!_longPressTimer.Enabled) return;
-        _longPressTimer.Stop();
+        if (_settings.LongPressButtonId != null && _settings.LongPressButtonId > 0)
+        {
+            if (!_longPressTimer.Enabled) return;
+            _longPressTimer.Stop();
+        }
+
         SimpleVJoyInterface.Instance.ButtonState(_settings.ButtonId, SimpleVJoyInterface.ButtonAction.Toggle);
         Connection.SetStateAsync(_buttonState ? 1u : 0u);
     }


### PR DESCRIPTION
The toggle button action had a bug where if the long press ID was set to 0, the short press action would not execute either. This was because when the long press button ID was 0, the long press timer was never started in the `KeyPressed` method. 

In `KeyReleased`, if the timer was not enabled, the method returned early, preventing the short press action from running. 

This fix updates the logic in `KeyReleased` to first check if a valid long press ID (> 0) is configured before checking the timer state. If the long press ID is 0, the timer check is bypassed and the short press action executes immediately.

---
*PR created automatically by Jules for task [2672018067757996897](https://jules.google.com/task/2672018067757996897) started by @bastianh*